### PR TITLE
Add type hints throughout the gmailsorter package

### DIFF
--- a/gmailsorter/__main__.py
+++ b/gmailsorter/__main__.py
@@ -4,7 +4,7 @@ import os
 from gmailsorter import Gmail, load_client_secrets_file
 
 
-def command_line_parser():
+def command_line_parser() -> None:
     """
     Main function primarily used for the command line interface
     """

--- a/gmailsorter/base/database.py
+++ b/gmailsorter/base/database.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 import pandas
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
-from sqlalchemy.orm import declarative_base
+from sqlalchemy import Boolean, Column, DateTime, Engine, ForeignKey, Integer, String
+from sqlalchemy.orm import Session, declarative_base
 from tqdm import tqdm
 
 Base = declarative_base()
@@ -58,19 +60,19 @@ class EmailFrom(Base):
 
 
 class DatabaseTemplate:
-    def __init__(self, session):
+    def __init__(self, session: Session) -> None:
         self._session = session
 
-    def close(self):
+    def close(self) -> None:
         self._session.close()
 
 
 class DatabaseInterface(DatabaseTemplate):
     @property
-    def session(self):
+    def session(self) -> Session:
         return self._session
 
-    def store_dataframe(self, df, user_id=1):
+    def store_dataframe(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         self._commit_content_table(df=df, user_id=user_id)
         self._commit_email_from_table(df=df, user_id=user_id)
         self._commit_email_to_table(df=df, user_id=user_id)
@@ -78,7 +80,7 @@ class DatabaseInterface(DatabaseTemplate):
         self._commit_label_table(df=df, user_id=user_id)
         self._commit_thread_table(df=df, user_id=user_id)
 
-    def list_email_ids(self, user_id=1):
+    def list_email_ids(self, user_id: int = 1) -> list[str]:
         return [
             instance.email_id
             for instance in self._session.query(EmailContent)
@@ -86,7 +88,9 @@ class DatabaseInterface(DatabaseTemplate):
             .order_by(EmailContent.id)
         ]
 
-    def mark_emails_as_deleted(self, message_id_lst, user_id=1):
+    def mark_emails_as_deleted(
+        self, message_id_lst: list[str], user_id: int = 1
+    ) -> None:
         for instance in (
             self._session.query(EmailContent)
             .filter(EmailContent.user_id == user_id)
@@ -96,14 +100,21 @@ class DatabaseInterface(DatabaseTemplate):
             instance.email_deleted = True
         self._session.commit()
 
-    def get_labels_to_update(self, message_id_lst, user_id=1):
+    def get_labels_to_update(
+        self, message_id_lst: list[str], user_id: int = 1
+    ) -> tuple[list[str], list[str], list[str]]:
         email_in_db_id = self.list_email_ids(user_id=user_id)
         new_messages_lst = [m for m in message_id_lst if m not in email_in_db_id]
         deleted_messages_lst = [m for m in email_in_db_id if m not in message_id_lst]
         message_label_updates_lst = [m for m in message_id_lst if m in email_in_db_id]
         return new_messages_lst, message_label_updates_lst, deleted_messages_lst
 
-    def update_labels(self, message_id_lst, message_meta_lst, user_id=1):
+    def update_labels(
+        self,
+        message_id_lst: list[str],
+        message_meta_lst: list[list[str]],
+        user_id: int = 1,
+    ) -> None:
         for message_id, message_labels in tqdm(
             iterable=zip(message_id_lst, message_meta_lst, strict=False),
             desc="Update labels",
@@ -149,7 +160,9 @@ class DatabaseInterface(DatabaseTemplate):
                     ]
                 self._session.commit()
 
-    def get_all_emails(self, include_deleted=False, user_id=1):
+    def get_all_emails(
+        self, include_deleted: bool = False, user_id: int = 1
+    ) -> pandas.DataFrame:
         if include_deleted:
             email_collect_lst = [
                 [
@@ -181,7 +194,9 @@ class DatabaseInterface(DatabaseTemplate):
             desc="Create dataframe from database",
         )
 
-    def get_emails_by_label(self, label_id, include_deleted=False, user_id=1):
+    def get_emails_by_label(
+        self, label_id: str, include_deleted: bool = False, user_id: int = 1
+    ) -> pandas.DataFrame:
         return self.get_email_collection(
             email_id_lst=[
                 email_id
@@ -195,7 +210,9 @@ class DatabaseInterface(DatabaseTemplate):
             desc="Create dataframe from emails by label",
         )
 
-    def get_emails_by_from(self, email_from, include_deleted=False, user_id=1):
+    def get_emails_by_from(
+        self, email_from: str, include_deleted: bool = False, user_id: int = 1
+    ) -> pandas.DataFrame:
         return self.get_email_collection(
             email_id_lst=[
                 email_id
@@ -209,7 +226,9 @@ class DatabaseInterface(DatabaseTemplate):
             desc="Create dataframe from emails by from",
         )
 
-    def get_emails_by_to(self, email_to, include_deleted=False, user_id=1):
+    def get_emails_by_to(
+        self, email_to: str, include_deleted: bool = False, user_id: int = 1
+    ) -> pandas.DataFrame:
         return self.get_email_collection(
             email_id_lst=[
                 email_id
@@ -223,7 +242,9 @@ class DatabaseInterface(DatabaseTemplate):
             desc="Create dataframe from emails by to",
         )
 
-    def get_emails_by_cc(self, email_cc, include_deleted=False, user_id=1):
+    def get_emails_by_cc(
+        self, email_cc: str, include_deleted: bool = False, user_id: int = 1
+    ) -> pandas.DataFrame:
         return self.get_email_collection(
             email_id_lst=[
                 email_id
@@ -237,7 +258,9 @@ class DatabaseInterface(DatabaseTemplate):
             desc="Create dataframe from emails by cc",
         )
 
-    def get_emails_by_thread(self, thread_id, include_deleted=False, user_id=1):
+    def get_emails_by_thread(
+        self, thread_id: str, include_deleted: bool = False, user_id: int = 1
+    ) -> pandas.DataFrame:
         return self.get_email_collection(
             email_id_lst=[
                 email_id
@@ -253,11 +276,11 @@ class DatabaseInterface(DatabaseTemplate):
 
     def get_email_collection(
         self,
-        email_id_lst,
-        include_deleted=False,
-        user_id=1,
-        desc="Create dataframe from email collection",
-    ):
+        email_id_lst: list[str],
+        include_deleted: bool = False,
+        user_id: int = 1,
+        desc: str = "Create dataframe from email collection",
+    ) -> pandas.DataFrame:
         if include_deleted:
             email_collect_lst = [
                 [
@@ -289,7 +312,7 @@ class DatabaseInterface(DatabaseTemplate):
             email_collect_lst=email_collect_lst, user_id=user_id, desc=desc
         )
 
-    def _commit_thread_table(self, df, user_id=1):
+    def _commit_thread_table(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         self._session.add_all(
             [
                 Threads(email_id=email_id, thread_id=thread_id, user_id=user_id)
@@ -298,7 +321,7 @@ class DatabaseInterface(DatabaseTemplate):
         )
         self._session.commit()
 
-    def _commit_email_from_table(self, df, user_id=1):
+    def _commit_email_from_table(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         self._session.add_all(
             [
                 EmailFrom(email_id=email_id, email_from=email_from, user_id=user_id)
@@ -307,7 +330,7 @@ class DatabaseInterface(DatabaseTemplate):
         )
         self._session.commit()
 
-    def _commit_label_table(self, df, user_id=1):
+    def _commit_label_table(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         label_lst = []
         for email_id, lid_lst in zip(df["id"], df["labels"], strict=False):
             for label_id in lid_lst:
@@ -317,7 +340,7 @@ class DatabaseInterface(DatabaseTemplate):
         self._session.add_all(label_lst)
         self._session.commit()
 
-    def _commit_email_to_table(self, df, user_id=1):
+    def _commit_email_to_table(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         email_to_lst = []
         for email_id, email_lst in zip(df["id"], df["to"], strict=False):
             for email_to in email_lst:
@@ -327,7 +350,7 @@ class DatabaseInterface(DatabaseTemplate):
         self._session.add_all(email_to_lst)
         self._session.commit()
 
-    def _commit_email_cc_table(self, df, user_id=1):
+    def _commit_email_cc_table(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         email_cc_lst = []
         for email_id, email_lst in zip(df["id"], df["cc"], strict=False):
             for email_cc in email_lst:
@@ -337,7 +360,7 @@ class DatabaseInterface(DatabaseTemplate):
         self._session.add_all(email_cc_lst)
         self._session.commit()
 
-    def _commit_content_table(self, df, user_id=1):
+    def _commit_content_table(self, df: pandas.DataFrame, user_id: int = 1) -> None:
         self._session.add_all(
             [
                 EmailContent(
@@ -356,8 +379,11 @@ class DatabaseInterface(DatabaseTemplate):
         self._session.commit()
 
     def _create_dataframe(
-        self, email_collect_lst, user_id=1, desc="Create dataframe from email list"
-    ):
+        self,
+        email_collect_lst: list[list[Any]],
+        user_id: int = 1,
+        desc: str = "Create dataframe from email list",
+    ) -> pandas.DataFrame:
         (
             email_id_lst,
             email_subject_lst,
@@ -434,6 +460,6 @@ class DatabaseInterface(DatabaseTemplate):
         )
 
 
-def get_email_database(engine, session):
+def get_email_database(engine: Engine, session: Session) -> DatabaseInterface:
     Base.metadata.create_all(engine)
     return DatabaseInterface(session=session)

--- a/gmailsorter/base/message.py
+++ b/gmailsorter/base/message.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Any
 
 _MAX_DATE_COMMAS = 2
 _DATE_HYPHEN_COUNT = 2
 
 
-def email_date_converter(email_date):
+def email_date_converter(email_date: Any) -> datetime | None:
     if not isinstance(email_date, str):
         return None
     if email_date[:1] == "\xa0":
@@ -35,46 +36,46 @@ def email_date_converter(email_date):
 
 
 class AbstractMessage(ABC):
-    def __init__(self, message_dict):
+    def __init__(self, message_dict: dict[str, Any]) -> None:
         self._message_dict = message_dict
 
     @abstractmethod
-    def get_from(self):
+    def get_from(self) -> str | None:
         pass
 
     @abstractmethod
-    def get_to(self):
+    def get_to(self) -> list[str]:
         pass
 
     @abstractmethod
-    def get_cc(self):
+    def get_cc(self) -> list[str]:
         pass
 
     @abstractmethod
-    def get_label_ids(self):
+    def get_label_ids(self) -> list[str]:
         pass
 
     @abstractmethod
-    def get_subject(self):
+    def get_subject(self) -> str | None:
         pass
 
     @abstractmethod
-    def get_date(self):
+    def get_date(self) -> datetime | None:
         pass
 
     @abstractmethod
-    def get_content(self):
+    def get_content(self) -> str | None:
         pass
 
     @abstractmethod
-    def get_thread_id(self):
+    def get_thread_id(self) -> str:
         pass
 
     @abstractmethod
-    def get_email_id(self):
+    def get_email_id(self) -> str:
         pass
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.get_email_id(),
             "threads": self.get_thread_id(),

--- a/gmailsorter/daemon/__main__.py
+++ b/gmailsorter/daemon/__main__.py
@@ -5,7 +5,7 @@ from gmailsorter.daemon.daemon import update
 from gmailsorter.daemon.shared import get_database_engine, load_config_file
 
 
-def _get_execution_mode(args):
+def _get_execution_mode(args: argparse.Namespace) -> str:
     if args.update and args.filter:
         return "all"
     elif args.update:
@@ -18,7 +18,7 @@ def _get_execution_mode(args):
         raise ValueError("Mode of execution undefined.")
 
 
-def command_line_parser():
+def command_line_parser() -> None:
     """
     Main function primarily used for the command line interface
     """

--- a/gmailsorter/daemon/daemon.py
+++ b/gmailsorter/daemon/daemon.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from google.auth.exceptions import RefreshError
 from googleapiclient.errors import HttpError
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session, sessionmaker
 
 from gmailsorter.daemon.shared import (
     JOB_STATUS_FAIL,
@@ -19,7 +22,9 @@ from gmailsorter.daemon.tasks import (
 )
 
 
-def load_user_data_from_database(session, mode):
+def load_user_data_from_database(
+    session: Session, mode: str
+) -> tuple[dict[str, list[int]], dict[int, dict[str, Any]]]:
     job_dict = get_all_tasks_to_execute(session=session, task_name=mode)
     user_id_lst = []
     for lst in job_dict.values():
@@ -41,21 +46,21 @@ def load_user_data_from_database(session, mode):
 
 
 def iterate_over_users(
-    user_id_lst,
-    token_detail_dict,
-    scopes,
-    engine,
-    session,
-    client_secrets_config,
-    database_update=True,
-    filter_messages=True,
-    n_estimators=100,
-    max_features=400,
-    random_state=42,
-    bootstrap=True,
-    include_deleted=False,
-    recommendation_ratio=0.9,
-):
+    user_id_lst: list[int],
+    token_detail_dict: dict[int, dict[str, Any]],
+    scopes: list[str],
+    engine: Engine,
+    session: Session,
+    client_secrets_config: dict[str, Any],
+    database_update: bool = True,
+    filter_messages: bool = True,
+    n_estimators: int = 100,
+    max_features: int = 400,
+    random_state: int = 42,
+    bootstrap: bool = True,
+    include_deleted: bool = False,
+    recommendation_ratio: float = 0.9,
+) -> None:
     for user_database_id in user_id_lst:
         token_user_dict = token_detail_dict[user_database_id]
         try:
@@ -149,16 +154,16 @@ def iterate_over_users(
 
 
 def update(
-    engine,
-    client_secrets_config,
-    mode,
-    n_estimators=100,
-    max_features=400,
-    random_state=42,
-    bootstrap=True,
-    include_deleted=False,
-    recommendation_ratio=0.9,
-):
+    engine: Engine,
+    client_secrets_config: dict[str, Any],
+    mode: str,
+    n_estimators: int = 100,
+    max_features: int = 400,
+    random_state: int = 42,
+    bootstrap: bool = True,
+    include_deleted: bool = False,
+    recommendation_ratio: float = 0.9,
+) -> None:
     session = sessionmaker(bind=engine)()
     job_dict, token_detail_dict = load_user_data_from_database(
         session=session, mode=mode

--- a/gmailsorter/daemon/shared.py
+++ b/gmailsorter/daemon/shared.py
@@ -1,14 +1,19 @@
 import json
+from datetime import datetime
+from typing import Any
 
 import google.oauth2.credentials
 import googleapiclient.discovery
-from sqlalchemy import Column, DateTime, Integer, String, create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import Column, DateTime, Engine, Integer, String, create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from gmailsorter.base import get_email_database
+from gmailsorter.base.database import DatabaseInterface as EmailDatabaseInterface
 from gmailsorter.google import GoogleMailBase
+from gmailsorter.google.database import DatabaseInterface as TokenDatabaseInterface
 from gmailsorter.google.database import get_token_database
 from gmailsorter.ml import get_machine_learning_database
+from gmailsorter.ml.database import MachineLearningDatabase
 
 # Modifying the labels of emails requires /auth/gmail.modify
 # https://developers.google.com/gmail/api/reference/rest/v1/users.messages/modify
@@ -70,20 +75,20 @@ class Task(Base):
 class GoogleMail(GoogleMailBase):
     def __init__(
         self,
-        scopes,
-        database_engine,
-        token,
-        refresh_token,
-        token_uri,
-        client_id,
-        client_secret,
-        expiry,
-        user_id="me",
-        db_user_id=1,
-        email_download_format="metadata",
-        serviceName="gmail",
-        version="v1",
-    ):
+        scopes: list[str],
+        database_engine: Engine,
+        token: str | None,
+        refresh_token: str | None,
+        token_uri: str | None,
+        client_id: str | None,
+        client_secret: str | None,
+        expiry: datetime | None,
+        user_id: str = "me",
+        db_user_id: int = 1,
+        email_download_format: str = "metadata",
+        serviceName: str = "gmail",
+        version: str = "v1",
+    ) -> None:
         """
         Gmail class to manage Emails via the Gmail API directly from Python
 
@@ -133,13 +138,13 @@ class GoogleMail(GoogleMailBase):
         )
 
     @property
-    def session(self):
+    def session(self) -> Session:
         return self._session
 
-    def close_database_connection(self):
+    def close_database_connection(self) -> None:
         self._session.close()
 
-    def create_filter_moving_all_labels(self, label_name):
+    def create_filter_moving_all_labels(self, label_name: str) -> str:
         """
         Create a filter to move all emails to the selected label.
 
@@ -192,10 +197,10 @@ class GoogleMail(GoogleMailBase):
 
     def create_label(
         self,
-        label_name,
-        label_list_visibility="labelHide",
-        message_list_visibility="hide",
-    ):
+        label_name: str,
+        label_list_visibility: str = "labelHide",
+        message_list_visibility: str = "hide",
+    ) -> str:
         """
         Create a new email label using the Google API and return the label ID. If the label already exists this function
         still returns the label ID. More information can be found in the Google API documentation:
@@ -227,14 +232,14 @@ class GoogleMail(GoogleMailBase):
             self._label_dict_inverse = {v: k for k, v in self._label_dict.items()}
             return result["id"]
 
-    def get_filter_list(self):
+    def get_filter_list(self) -> list[dict[str, Any]]:
         results = self._service.users().settings().filters().list(userId="me").execute()
         if "filter" in results:
             return results["filter"]
         else:
             return []
 
-    def get_status_dict(self, label_name):
+    def get_status_dict(self, label_name: str) -> dict[str, str | None]:
         status_dict = get_tasks_status_for_user(
             session=self._session, user_id=self._db_user_id
         )
@@ -257,7 +262,9 @@ class GoogleMail(GoogleMailBase):
             status_dict["filter"] = JOB_STATUS_FAIL
         return status_dict
 
-    def _create_databases(self, engine):
+    def _create_databases(
+        self, engine: Engine
+    ) -> tuple[EmailDatabaseInterface, MachineLearningDatabase, TokenDatabaseInterface]:
         self._session = sessionmaker(bind=engine)()
         db_email = get_email_database(engine=engine, session=self._session)
         db_ml = get_machine_learning_database(engine=engine, session=self._session)
@@ -265,13 +272,15 @@ class GoogleMail(GoogleMailBase):
         return db_email, db_ml, db_token
 
 
-def get_database_engine(connection_str):
+def get_database_engine(connection_str: str) -> Engine:
     engine = create_engine(connection_str)
     Base.metadata.create_all(engine)
     return engine
 
 
-def get_task_status_for_user(session, user_id, task_name):
+def get_task_status_for_user(
+    session: Session, user_id: int, task_name: str
+) -> str | None:
     status_obj = (
         session.query(Task)
         .filter(Task.user_id == user_id)
@@ -284,7 +293,7 @@ def get_task_status_for_user(session, user_id, task_name):
         return None
 
 
-def get_tasks_status_for_user(session, user_id):
+def get_tasks_status_for_user(session: Session, user_id: int) -> dict[str, str | None]:
     return {
         task_name: get_task_status_for_user(
             session=session, user_id=user_id, task_name=task_name
@@ -293,10 +302,10 @@ def get_tasks_status_for_user(session, user_id):
     }
 
 
-def get_token(session, user_id):
+def get_token(session: Session, user_id: int) -> GoogleToken | None:
     return session.query(GoogleToken).filter_by(user_id=user_id).first()
 
 
-def load_config_file(file_name):
+def load_config_file(file_name: str) -> dict[str, Any]:
     with open(file_name) as json_file:
         return json.load(json_file)

--- a/gmailsorter/daemon/tasks.py
+++ b/gmailsorter/daemon/tasks.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from sqlalchemy.orm import Session
+
 from gmailsorter.daemon.shared import (
     JOB_STATUS_INIT,
     JOB_STATUS_SUCCESS,
@@ -8,7 +10,7 @@ from gmailsorter.daemon.shared import (
 )
 
 
-def create_tasks_for_new_users(session, user_id):
+def create_tasks_for_new_users(session: Session, user_id: int) -> None:
     task_lst = []
     task_update_from_database = (
         session.query(Task)
@@ -45,7 +47,9 @@ def create_tasks_for_new_users(session, user_id):
         session.commit()
 
 
-def update_task_status(session, user_id, task_name, status):
+def update_task_status(
+    session: Session, user_id: int, task_name: str, status: str
+) -> None:
     task = (
         session.query(Task)
         .filter(Task.user_id == user_id)
@@ -57,7 +61,9 @@ def update_task_status(session, user_id, task_name, status):
     session.commit()
 
 
-def get_all_tasks_to_execute(session, task_name="all"):
+def get_all_tasks_to_execute(
+    session: Session, task_name: str = "all"
+) -> dict[str, list[int]]:
     if task_name not in ["all", "update", "fetch", "select"]:
         raise ValueError(
             'The task_name parameter has to be one of the following ["all", "update", "fetch", "select"]'

--- a/gmailsorter/google/authentication.py
+++ b/gmailsorter/google/authentication.py
@@ -1,19 +1,23 @@
+from typing import Any
+
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build
+from googleapiclient.discovery import Resource, build
+
+from gmailsorter.google.database import DatabaseInterface
 
 
 def create_service(
-    client_config,
-    api_name,
-    api_version,
-    scopes,
-    database,
-    database_user_id,
-    port=8080,
-):
+    client_config: dict[str, Any],
+    api_name: str,
+    api_version: str,
+    scopes: list[str],
+    database: DatabaseInterface,
+    database_user_id: int,
+    port: int = 8080,
+) -> Resource:
     cred = None
 
     token = database.get_token(user_id=database_user_id)
@@ -43,7 +47,12 @@ def create_service(
     return build(api_name, api_version, credentials=cred)
 
 
-def validate_token(cred, client_config, scopes, port=8080):
+def validate_token(
+    cred: Credentials | None,
+    client_config: dict[str, Any],
+    scopes: list[str],
+    port: int = 8080,
+) -> Credentials:
     token_valid = False
     if cred and cred.expired and cred.refresh_token:
         try:

--- a/gmailsorter/google/database.py
+++ b/gmailsorter/google/database.py
@@ -1,5 +1,8 @@
-from sqlalchemy import Column, DateTime, Integer, String
-from sqlalchemy.orm import declarative_base
+from typing import Any
+
+from google.oauth2.credentials import Credentials
+from sqlalchemy import Column, DateTime, Engine, Integer, String
+from sqlalchemy.orm import Session, declarative_base
 
 from gmailsorter.base.database import DatabaseTemplate
 
@@ -21,10 +24,12 @@ class GoogleToken(Base):
 
 class DatabaseInterface(DatabaseTemplate):
     @property
-    def session(self):
+    def session(self) -> Session:
         return self._session
 
-    def update_token_with_dict(self, token, credentials, commit=True):
+    def update_token_with_dict(
+        self, token: GoogleToken, credentials: Credentials, commit: bool = True
+    ) -> None:
         token.token = credentials.token
         token.refresh_token = credentials.refresh_token
         token.token_uri = credentials.token_uri
@@ -36,7 +41,7 @@ class DatabaseInterface(DatabaseTemplate):
         if commit:
             self._session.commit()
 
-    def get_token(self, user_id):
+    def get_token(self, user_id: int) -> GoogleToken:
         token = self._session.query(GoogleToken).filter_by(user_id=user_id).first()
         if token is None:
             return GoogleToken(user_id=user_id)
@@ -44,7 +49,7 @@ class DatabaseInterface(DatabaseTemplate):
             return token
 
     @staticmethod
-    def token_to_dict(token):
+    def token_to_dict(token: GoogleToken) -> dict[str, Any]:
         return {
             "token": token.token,
             "refresh_token": token.refresh_token,
@@ -56,6 +61,6 @@ class DatabaseInterface(DatabaseTemplate):
         }
 
 
-def get_token_database(engine, session):
+def get_token_database(engine: Engine, session: Session) -> DatabaseInterface:
     Base.metadata.create_all(engine)
     return DatabaseInterface(session=session)

--- a/gmailsorter/google/mail.py
+++ b/gmailsorter/google/mail.py
@@ -1,9 +1,14 @@
+from typing import Any
+
 import pandas
+from googleapiclient.discovery import Resource
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from tqdm import tqdm
 
 from gmailsorter.base import get_email_database
+from gmailsorter.base.database import DatabaseInterface as EmailDatabaseInterface
+from gmailsorter.google.database import DatabaseInterface as TokenDatabaseInterface
 from gmailsorter.google.database import get_token_database
 from gmailsorter.google.message import get_email_dict
 from gmailsorter.ml import (
@@ -12,19 +17,24 @@ from gmailsorter.ml import (
     get_machine_learning_database,
     get_predictions_from_machine_learning_models,
 )
+from gmailsorter.ml.database import MachineLearningDatabase
+
+_DatabaseTriple = tuple[
+    EmailDatabaseInterface, MachineLearningDatabase, TokenDatabaseInterface
+]
 
 
 class GoogleMailBase:
     def __init__(
         self,
-        google_mail_service,
-        database_email=None,
-        database_ml=None,
-        database_token=None,
-        user_id="me",
-        db_user_id=1,
-        email_download_format="metadata",
-    ):
+        google_mail_service: Resource,
+        database_email: EmailDatabaseInterface | None = None,
+        database_ml: MachineLearningDatabase | None = None,
+        database_token: TokenDatabaseInterface | None = None,
+        user_id: str = "me",
+        db_user_id: int = 1,
+        email_download_format: str = "metadata",
+    ) -> None:
         """
         Gmail class to manage Emails via the Gmail API directly from Python
 
@@ -48,10 +58,10 @@ class GoogleMailBase:
         self._label_dict_inverse = {v: k for k, v in self._label_dict.items()}
 
     @property
-    def labels(self):
+    def labels(self) -> list[str]:
         return list(self._label_dict.keys())
 
-    def download_emails_for_label(self, label):
+    def download_emails_for_label(self, label: str) -> pandas.DataFrame:
         """
         Download emails for a specific label
 
@@ -69,9 +79,9 @@ class GoogleMailBase:
 
     def filter_messages_from_server(
         self,
-        label,
-        recommendation_ratio=0.9,
-    ):
+        label: str,
+        recommendation_ratio: float = 0.9,
+    ) -> None:
         """
         Filter new emails based on machine learning model recommendations.
 
@@ -102,12 +112,12 @@ class GoogleMailBase:
 
     def fit_machine_learning_model_to_database(
         self,
-        n_estimators=100,
-        max_features=400,
-        random_state=42,
-        bootstrap=True,
-        include_deleted=False,
-    ):
+        n_estimators: int = 100,
+        max_features: int = 400,
+        random_state: int = 42,
+        bootstrap: bool = True,
+        include_deleted: bool = False,
+    ) -> None:
         """
         Fit machine learning models to emails stored in database and afterwards store machine learning models in
         database.
@@ -145,7 +155,9 @@ class GoogleMailBase:
             commit=True,
         )
 
-    def get_all_emails_in_database(self, include_deleted=False):
+    def get_all_emails_in_database(
+        self, include_deleted: bool = False
+    ) -> pandas.DataFrame:
         """
         Get all emails stored in the local database
 
@@ -159,7 +171,12 @@ class GoogleMailBase:
             include_deleted=include_deleted, user_id=self._db_user_id
         )
 
-    def update_database(self, quick=False, label_lst=None, email_format=None):
+    def update_database(
+        self,
+        quick: bool = False,
+        label_lst: list[str] | None = None,
+        email_format: str | None = None,
+    ) -> None:
         """
         Update local email database
 
@@ -196,7 +213,9 @@ class GoogleMailBase:
                 message_id_lst=new_messages_lst, email_format=email_format
             )
 
-    def _download_messages_to_dataframe(self, message_id_lst, email_format=None):
+    def _download_messages_to_dataframe(
+        self, message_id_lst: list[str], email_format: str | None = None
+    ) -> pandas.DataFrame:
         """
         Download a list of messages based on their email IDs and store the content in a pandas.DataFrame.
 
@@ -226,7 +245,7 @@ class GoogleMailBase:
             ]
         )
 
-    def _get_labels_for_email(self, message_id):
+    def _get_labels_for_email(self, message_id: str) -> list[str]:
         """
         Get labels for email
 
@@ -246,7 +265,7 @@ class GoogleMailBase:
         else:
             return []
 
-    def _get_labels_for_emails(self, message_id_lst):
+    def _get_labels_for_emails(self, message_id_lst: list[str]) -> list[list[str]]:
         """
         Get labels for a list of emails
 
@@ -263,12 +282,17 @@ class GoogleMailBase:
             )
         ]
 
-    def _get_label_translate_dict(self):
+    def _get_label_translate_dict(self) -> dict[str, str]:
         results = self._service.users().labels().list(userId=self._userid).execute()
         labels = results.get("labels", [])
         return {label["name"]: label["id"] for label in labels}
 
-    def _get_message_detail(self, message_id, email_format=None, metadata_headers=None):
+    def _get_message_detail(
+        self,
+        message_id: str,
+        email_format: str | None = None,
+        metadata_headers: list[str] | None = None,
+    ) -> dict[str, Any]:
         """
         Get details of a specific email message based on its email ID
 
@@ -296,7 +320,12 @@ class GoogleMailBase:
             .execute()
         )
 
-    def _get_messages_page(self, label_ids, query_string, next_page_token=None):
+    def _get_messages_page(
+        self,
+        label_ids: list[str],
+        query_string: str,
+        next_page_token: str | None = None,
+    ) -> list[Any]:
         message_list_response = (
             self._service.users()
             .messages()
@@ -314,7 +343,9 @@ class GoogleMailBase:
             message_list_response.get("nextPageToken"),
         ]
 
-    def _get_messages(self, query_string="", label_ids=None):
+    def _get_messages(
+        self, query_string: str = "", label_ids: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         if label_ids is None:
             label_ids = []
         message_items_lst, next_page_token = self._get_messages_page(
@@ -332,13 +363,16 @@ class GoogleMailBase:
         return message_items_lst
 
     def _modify_message_labels(
-        self, message_id, label_id_remove_lst=None, label_id_add_lst=None
-    ):
+        self,
+        message_id: str,
+        label_id_remove_lst: list[str] | None = None,
+        label_id_add_lst: list[str] | None = None,
+    ) -> None:
         if label_id_remove_lst is None:
             label_id_remove_lst = []
         if label_id_add_lst is None:
             label_id_add_lst = []
-        body_dict = {}
+        body_dict: dict[str, list[str]] = {}
         if len(label_id_remove_lst) > 0:
             body_dict["removeLabelIds"] = label_id_remove_lst
         if len(label_id_add_lst) > 0:
@@ -348,7 +382,9 @@ class GoogleMailBase:
                 userId=self._userid, id=message_id, body=body_dict
             ).execute()
 
-    def _move_emails(self, move_email_dict, label_to_ignore):
+    def _move_emails(
+        self, move_email_dict: dict[str, str | None], label_to_ignore: str
+    ) -> None:
         label_existing = self._label_dict[label_to_ignore]
         for message_id, label_add in tqdm(
             iterable=move_email_dict.items(), desc="Move emails"
@@ -361,8 +397,11 @@ class GoogleMailBase:
                 )
 
     def _search_email_on_server(
-        self, query_string="", label_lst=None, only_message_ids=False
-    ):
+        self,
+        query_string: str = "",
+        label_lst: list[str] | None = None,
+        only_message_ids: bool = False,
+    ) -> list[dict[str, Any]] | list[str]:
         """
         Search emails either by a specific query or optionally limit your search to a list of labels
 
@@ -385,7 +424,9 @@ class GoogleMailBase:
         else:
             return [d["id"] for d in message_id_lst]
 
-    def _store_emails_in_database(self, message_id_lst, email_format=None):
+    def _store_emails_in_database(
+        self, message_id_lst: list[str], email_format: str | None = None
+    ) -> None:
         df = self._download_messages_to_dataframe(
             message_id_lst=message_id_lst, email_format=email_format
         )
@@ -393,7 +434,7 @@ class GoogleMailBase:
             self._db_email.store_dataframe(df=df, user_id=self._db_user_id)
 
     @staticmethod
-    def _create_databases(connection_str):
+    def _create_databases(connection_str: str) -> _DatabaseTriple:
         engine = create_engine(connection_str)
         session = sessionmaker(bind=engine)()
         db_email = get_email_database(engine=engine, session=session)
@@ -402,5 +443,5 @@ class GoogleMailBase:
         return db_email, db_ml, db_token
 
     @staticmethod
-    def _get_message_ids(message_lst):
+    def _get_message_ids(message_lst: list[dict[str, Any]]) -> list[str]:
         return [d["id"] for d in message_lst]

--- a/gmailsorter/google/mail.py
+++ b/gmailsorter/google/mail.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pandas
 from googleapiclient.discovery import Resource
@@ -117,7 +117,7 @@ class GoogleMailBase:
         random_state: int = 42,
         bootstrap: bool = True,
         include_deleted: bool = False,
-        max_workers: Optional[int] = None,
+        max_workers: int | None = None,
     ):
         """
         Fit machine learning models to emails stored in database and afterwards store machine learning models in

--- a/gmailsorter/google/message.py
+++ b/gmailsorter/google/message.py
@@ -1,27 +1,29 @@
 import base64
+from datetime import datetime
 from html.parser import HTMLParser
 from io import StringIO
+from typing import Any
 
 from gmailsorter.base.message import AbstractMessage, email_date_converter
 
 
 # https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
 class MLStripper(HTMLParser):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.reset()
         self.strict = False
         self.convert_charrefs = True
         self.text = StringIO()
 
-    def handle_data(self, d):
+    def handle_data(self, d: str) -> None:
         self.text.write(d)
 
-    def get_data(self):
+    def get_data(self) -> str:
         return self.text.getvalue()
 
 
-def get_email_dict(message):
+def get_email_dict(message: dict[str, Any]) -> dict[str, Any] | None:
     try:
         return Message(message_dict=message).to_dict()
     except ValueError as e:
@@ -30,10 +32,10 @@ def get_email_dict(message):
 
 
 class Message(AbstractMessage):
-    def __init__(self, message_dict):
+    def __init__(self, message_dict: dict[str, Any]) -> None:
         self._message_dict = message_dict
 
-    def get_from(self):
+    def get_from(self) -> str | None:
         email_lst = self._split_emails(
             email_lst=self.get_header_field_from_message(field="From")
         )
@@ -42,31 +44,31 @@ class Message(AbstractMessage):
         else:
             return None
 
-    def get_to(self):
+    def get_to(self) -> list[str]:
         return self._split_emails(
             email_lst=self.get_header_field_from_message(field="To")
         )
 
-    def get_cc(self):
+    def get_cc(self) -> list[str]:
         return self._split_emails(
             email_lst=self.get_header_field_from_message(field="Cc")
         )
 
-    def get_label_ids(self):
+    def get_label_ids(self) -> list[str]:
         if "labelIds" in self._message_dict:
             return self._message_dict["labelIds"]
         else:
             return []
 
-    def get_subject(self):
+    def get_subject(self) -> str | None:
         return self.get_header_field_from_message(field="Subject")
 
-    def get_date(self):
+    def get_date(self) -> datetime | None:
         return email_date_converter(
             email_date=self.get_header_field_from_message(field="Date")
         )
 
-    def get_content(self):
+    def get_content(self) -> str | None:
         if "parts" in self._message_dict["payload"]:
             return self._get_parts_content(
                 message_parts=self._message_dict["payload"]["parts"]
@@ -76,13 +78,13 @@ class Message(AbstractMessage):
                 message_parts=[self._message_dict["payload"]]
             )
 
-    def get_thread_id(self):
+    def get_thread_id(self) -> str:
         return self._message_dict["threadId"]
 
-    def get_email_id(self):
+    def get_email_id(self) -> str:
         return self._message_dict["id"]
 
-    def get_header_field_from_message(self, field):
+    def get_header_field_from_message(self, field: str) -> str | None:
         lst = [
             entry["value"]
             for entry in self._message_dict["payload"]["headers"]
@@ -93,7 +95,7 @@ class Message(AbstractMessage):
         else:
             return None
 
-    def _get_parts_content(self, message_parts):
+    def _get_parts_content(self, message_parts: list[dict[str, Any]]) -> str | None:
         content_types = [p["mimeType"] for p in message_parts if "mimeType" in p]
         if "text/plain" in content_types:
             return self._get_email_body(
@@ -118,7 +120,7 @@ class Message(AbstractMessage):
         else:
             return None
 
-    def _split_emails(self, email_lst):
+    def _split_emails(self, email_lst: str | None) -> list[str]:
         if email_lst is not None:
             email_split_lst = email_lst.split(", ")
             return [
@@ -130,7 +132,7 @@ class Message(AbstractMessage):
             return []
 
     @staticmethod
-    def _get_email_body(message_parts):
+    def _get_email_body(message_parts: dict[str, Any]) -> str:
         if "body" in message_parts and "data" in message_parts["body"]:
             return base64.urlsafe_b64decode(
                 message_parts["body"]["data"].encode("UTF-8")
@@ -139,13 +141,13 @@ class Message(AbstractMessage):
             return ""
 
     @staticmethod
-    def _strip_tags(html):
+    def _strip_tags(html: str) -> str:
         s = MLStripper()
         s.feed(html)
         return s.get_data()
 
     @staticmethod
-    def _get_email_address(email):
+    def _get_email_address(email: str) -> str:
         email_split = email.split("<")
         if len(email_split) == 1:
             return email.lower()

--- a/gmailsorter/local.py
+++ b/gmailsorter/local.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from gmailsorter.google import GoogleMailBase, create_service
 
@@ -6,13 +7,13 @@ from gmailsorter.google import GoogleMailBase, create_service
 class Gmail(GoogleMailBase):
     def __init__(
         self,
-        client_config,
-        connection_str,
-        user_id="me",
-        db_user_id=1,
-        port=8080,
-        email_download_format="metadata",
-    ):
+        client_config: dict[str, Any],
+        connection_str: str,
+        user_id: str = "me",
+        db_user_id: int = 1,
+        port: int = 8080,
+        email_download_format: str = "metadata",
+    ) -> None:
         """
         Gmail class to manage Emails via the Gmail API directly from Python
 
@@ -61,6 +62,6 @@ class Gmail(GoogleMailBase):
         )
 
 
-def load_client_secrets_file(client_secrets_file):
+def load_client_secrets_file(client_secrets_file: str) -> dict[str, Any]:
     with open(client_secrets_file) as json_file:
         return json.load(json_file)

--- a/gmailsorter/ml/database.py
+++ b/gmailsorter/ml/database.py
@@ -1,7 +1,8 @@
 import pickle
 
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import declarative_base
+from sklearn.ensemble import RandomForestClassifier
+from sqlalchemy import Column, Engine, Integer, String
+from sqlalchemy.orm import Session, declarative_base
 
 from gmailsorter.base.database import DatabaseTemplate
 
@@ -24,7 +25,13 @@ class MachineLearningFeatures(Base):
 
 
 class MachineLearningDatabase(DatabaseTemplate):
-    def store_models(self, model_dict, feature_lst, user_id=1, commit=True):
+    def store_models(
+        self,
+        model_dict: dict[str, RandomForestClassifier],
+        feature_lst: list[str],
+        user_id: int = 1,
+        commit: bool = True,
+    ) -> None:
         """
         Store machine learning models in database
 
@@ -98,7 +105,9 @@ class MachineLearningDatabase(DatabaseTemplate):
         if commit:
             self._session.commit()
 
-    def load_models(self, user_id=1):
+    def load_models(
+        self, user_id: int = 1
+    ) -> tuple[dict[str, RandomForestClassifier], list[str]]:
         """
         Load models from database
 
@@ -119,7 +128,7 @@ class MachineLearningDatabase(DatabaseTemplate):
             for label_obj in label_obj_lst
         }, feature_lst
 
-    def _get_labels(self, user_id=1):
+    def _get_labels(self, user_id: int = 1) -> list[str]:
         return [
             label[0]
             for label in self._session.query(MachineLearningLabels.label_id)
@@ -127,7 +136,7 @@ class MachineLearningDatabase(DatabaseTemplate):
             .all()
         ]
 
-    def get_features(self, user_id=1):
+    def get_features(self, user_id: int = 1) -> list[str]:
         return [
             feature_obj.feature
             for feature_obj in (
@@ -138,6 +147,8 @@ class MachineLearningDatabase(DatabaseTemplate):
         ]
 
 
-def get_machine_learning_database(engine, session):
+def get_machine_learning_database(
+    engine: Engine, session: Session
+) -> MachineLearningDatabase:
     Base.metadata.create_all(engine)
     return MachineLearningDatabase(session=session)

--- a/gmailsorter/ml/encoding.py
+++ b/gmailsorter/ml/encoding.py
@@ -1,10 +1,15 @@
+from typing import Any
+
 import numpy as np
 import pandas
 
 
 def encode_df_for_machine_learning(
-    df, feature_lst=None, label_lst=None, return_labels=False
-):
+    df: pandas.DataFrame,
+    feature_lst: list[str] | np.ndarray | None = None,
+    label_lst: list[str] | np.ndarray | None = None,
+    return_labels: bool = False,
+) -> pandas.DataFrame | tuple[pandas.DataFrame, pandas.DataFrame]:
     """
     Encode a given dataframe for machine learning. Either based on a list of existing features and labels or by
     generating the features and labels from the dataframe. By default, only the dataframe with features is returned
@@ -52,7 +57,9 @@ def encode_df_for_machine_learning(
         return df_all_features, df_all_encode[label_lst]
 
 
-def one_hot_encoding(df, feature_lst=None):
+def one_hot_encoding(
+    df: pandas.DataFrame, feature_lst: list[str] | None = None
+) -> pandas.DataFrame:
     """
     Binary one hot encoding of features in a pandas DataFrame
 
@@ -116,7 +123,7 @@ def one_hot_encoding(df, feature_lst=None):
 
 
 # Helper functions for one hot encoding
-def _build_red_lst(df_column):
+def _build_red_lst(df_column: np.ndarray) -> list[str]:
     collect_lst = []
     for lst in df_column:
         for entry in lst:
@@ -129,7 +136,7 @@ def _build_red_lst(df_column):
     return list(set(collect_lst))
 
 
-def _get_lst_without_none(lst, column):
+def _get_lst_without_none(lst: list[Any], column: str) -> list[str]:
     return [
         column + "_" + entry
         for entry in lst
@@ -137,7 +144,7 @@ def _get_lst_without_none(lst, column):
     ]
 
 
-def _single_entry_df(red_lst, value_lst):
+def _single_entry_df(red_lst: np.ndarray, value_lst: np.ndarray) -> np.ndarray:
     return np.array(
         [
             [
@@ -150,7 +157,7 @@ def _single_entry_df(red_lst, value_lst):
     ).astype("float64")
 
 
-def _single_entry_email_df(red_lst, value_lst):
+def _single_entry_email_df(red_lst: list[str], value_lst: np.ndarray) -> np.ndarray:
     return np.array(
         [
             [
@@ -169,7 +176,7 @@ def _single_entry_email_df(red_lst, value_lst):
     ).astype("float64")
 
 
-def _list_entry_df(red_lst, value_lst):
+def _list_entry_df(red_lst: list[str], value_lst: np.ndarray) -> np.ndarray:
     return np.array(
         [
             [1 if red_entry in email else 0 for red_entry in red_lst]
@@ -178,7 +185,7 @@ def _list_entry_df(red_lst, value_lst):
     ).astype("float64")
 
 
-def _list_entry_email_df(red_lst, value_lst):
+def _list_entry_email_df(red_lst: list[str], value_lst: np.ndarray) -> np.ndarray:
     return np.array(
         [
             [1 if any(red_entry in e for e in email) else 0 for red_entry in red_lst]

--- a/gmailsorter/ml/model.py
+++ b/gmailsorter/ml/model.py
@@ -1,11 +1,19 @@
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
+import pandas
 from sklearn.ensemble import RandomForestClassifier
 from tqdm import tqdm
 
 
-def train_random_forest(n_estimators, random_state, bootstrap, max_features, X, y):
+def train_random_forest(
+    n_estimators: int,
+    random_state: int,
+    bootstrap: bool,
+    max_features: int,
+    X: pandas.DataFrame,
+    y: pandas.Series,
+) -> RandomForestClassifier:
     """
     Train a random forest classifier
 
@@ -29,14 +37,14 @@ def train_random_forest(n_estimators, random_state, bootstrap, max_features, X, 
 
 
 def fit_machine_learning_models(
-    df_all_features,
-    df_all_labels,
-    n_estimators=100,
-    max_features=400,
-    random_state=42,
-    bootstrap=True,
-    max_workers=None,
-):
+    df_all_features: pandas.DataFrame,
+    df_all_labels: pandas.DataFrame,
+    n_estimators: int = 100,
+    max_features: int = 400,
+    random_state: int = 42,
+    bootstrap: bool = True,
+    max_workers: int | None = None,
+) -> dict[str, RandomForestClassifier]:
     """
     Train machine learning models
 
@@ -75,8 +83,10 @@ def fit_machine_learning_models(
 
 
 def get_predictions_from_machine_learning_models(
-    df_features, model_dict, recommendation_ratio=0.9
-):
+    df_features: pandas.DataFrame,
+    model_dict: dict[str, RandomForestClassifier],
+    recommendation_ratio: float = 0.9,
+) -> dict[str, str | None]:
     """
     Get recommendations from machine learning models
 

--- a/gmailsorter/webapp/app.py
+++ b/gmailsorter/webapp/app.py
@@ -29,7 +29,7 @@ from gmailsorter.webapp.googleapi import (
     reset_user_status,
 )
 from gmailsorter.webapp.render import color_for_status
-from gmailsorter.webapp.user import get_flask_user
+from gmailsorter.webapp.user import FlaskUser, get_flask_user
 
 # Flask app setup
 app = flask.Flask(
@@ -47,18 +47,18 @@ login_manager.init_app(app)
 
 
 @login_manager.unauthorized_handler
-def unauthorized():
+def unauthorized() -> tuple[str, int]:
     return "You must be logged in to access this content.", 403
 
 
 # Flask-Login helper to retrieve a user from our db
 @login_manager.user_loader
-def load_user(user_id):
+def load_user(user_id: str) -> FlaskUser | None:
     return get_flask_user(engine=ENGINE, google_id=user_id, update=False)
 
 
 @app.route("/")
-def index():
+def index() -> str:
     if current_user.is_authenticated:
         # Access Gmail
         status_dict, error = get_user_status(
@@ -105,7 +105,7 @@ def index():
 
 
 @app.route("/authorize")
-def authorize():
+def authorize() -> flask.Response:
     authorization_url, state, code_verifier = get_authentication_url(
         client_config=CLIENT_SECRETS_CONFIG,
         scopes=SCOPES,
@@ -121,7 +121,7 @@ def authorize():
 
 @app.route("/reset")
 @login_required
-def reset_status():
+def reset_status() -> str | flask.Response:
     status_dict, error = reset_user_status(
         scopes=SCOPES,
         database_engine=ENGINE,
@@ -145,7 +145,7 @@ def reset_status():
 
 
 @app.route("/oauth2callback")
-def oauth2callback():
+def oauth2callback() -> flask.Response | tuple[str, int]:
     # Specify the state when creating the flow in the callback so that it can
     # verified in the authorization server response.
     state = flask.session["state"]
@@ -191,12 +191,12 @@ def oauth2callback():
 
 @app.route("/logout")
 @login_required
-def logout():
+def logout() -> flask.Response:
     logout_user()
     return flask.redirect(flask.url_for("index"))
 
 
-def run_app():
+def run_app() -> None:
     # When running locally, disable OAuthlib's HTTPs verification.
     # ACTION ITEM for developers:
     #     When running in production *do not* leave this option enabled.

--- a/gmailsorter/webapp/database.py
+++ b/gmailsorter/webapp/database.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
 from gmailsorter.daemon import (
     GoogleToken,
     SQLUser,
@@ -6,18 +10,18 @@ from gmailsorter.daemon import (
 
 
 def create_user_in_database(
-    session,
-    google_id,
-    name,
-    email,
-    profile_pic,
-    token,
-    refresh_token,
-    token_uri,
-    client_id,
-    client_secret,
-    expiry,
-):
+    session: Session,
+    google_id: str,
+    name: str | None,
+    email: str | None,
+    profile_pic: str | None,
+    token: str | None,
+    refresh_token: str | None,
+    token_uri: str | None,
+    client_id: str | None,
+    client_secret: str | None,
+    expiry: datetime | None,
+) -> int:
     user = SQLUser(
         google_id=google_id,
         name=name,
@@ -41,8 +45,15 @@ def create_user_in_database(
 
 
 def update_token_in_database(
-    session, user_id, token, refresh_token, token_uri, client_id, client_secret, expiry
-):
+    session: Session,
+    user_id: int,
+    token: str | None,
+    refresh_token: str | None,
+    token_uri: str | None,
+    client_id: str | None,
+    client_secret: str | None,
+    expiry: datetime | None,
+) -> None:
     token_obj = get_token(session=session, user_id=user_id)
     if token_obj is None:
         token_obj = GoogleToken(user_id=user_id)

--- a/gmailsorter/webapp/googleapi.py
+++ b/gmailsorter/webapp/googleapi.py
@@ -1,9 +1,13 @@
 # Based on https://developers.google.com/identity/protocols/oauth2/web-server#python
+from datetime import datetime
+from typing import Any
+
 import google.oauth2.credentials
 import google_auth_oauthlib.flow
 import googleapiclient.discovery
 from google.auth.exceptions import RefreshError
 from googleapiclient.errors import HttpError
+from sqlalchemy import Engine
 
 from gmailsorter.daemon import (
     GoogleMail,
@@ -12,7 +16,9 @@ from gmailsorter.daemon import (
 )
 
 
-def get_authentication_url(client_config, scopes, redirect_uri):
+def get_authentication_url(
+    client_config: dict[str, Any], scopes: list[str], redirect_uri: str
+) -> tuple[str, str, str]:
     # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
     flow = google_auth_oauthlib.flow.Flow.from_client_config(
         client_config=client_config, scopes=scopes
@@ -35,8 +41,13 @@ def get_authentication_url(client_config, scopes, redirect_uri):
 
 
 def get_google_credentials(
-    client_config, scopes, state, code_verifier, redirect_uri, authorization_response
-):
+    client_config: dict[str, Any],
+    scopes: list[str],
+    state: str,
+    code_verifier: str,
+    redirect_uri: str,
+    authorization_response: str,
+) -> dict[str, Any]:
     # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
     flow = google_auth_oauthlib.flow.Flow.from_client_config(
         client_config=client_config, scopes=scopes, state=state
@@ -54,17 +65,17 @@ def get_google_credentials(
 
 
 def get_user_status(
-    scopes,
-    database_engine,
-    token,
-    refresh_token,
-    token_uri,
-    client_id,
-    client_secret,
-    expiry,
-    db_user_id,
-    label_name,
-):
+    scopes: list[str],
+    database_engine: Engine,
+    token: str | None,
+    refresh_token: str | None,
+    token_uri: str | None,
+    client_id: str | None,
+    client_secret: str | None,
+    expiry: datetime | None,
+    db_user_id: int,
+    label_name: str,
+) -> tuple[dict[str, str | None], str | None]:
     try:
         gmail = GoogleMail(
             scopes=scopes,
@@ -93,16 +104,16 @@ def get_user_status(
 
 
 def reset_user_status(
-    scopes,
-    database_engine,
-    token,
-    refresh_token,
-    token_uri,
-    client_id,
-    client_secret,
-    expiry,
-    db_user_id,
-):
+    scopes: list[str],
+    database_engine: Engine,
+    token: str | None,
+    refresh_token: str | None,
+    token_uri: str | None,
+    client_id: str | None,
+    client_secret: str | None,
+    expiry: datetime | None,
+    db_user_id: int,
+) -> tuple[dict[str, str], str | None]:
     try:
         gmail = GoogleMail(
             scopes=scopes,
@@ -137,7 +148,9 @@ def reset_user_status(
         return {"update": "success", "fetch": "success"}, None
 
 
-def get_user_info(credentials_dict, service_name="oauth2", version="v2"):
+def get_user_info(
+    credentials_dict: dict[str, Any], service_name: str = "oauth2", version: str = "v2"
+) -> tuple[dict[str, Any] | None, str | None, google.oauth2.credentials.Credentials]:
     credentials = google.oauth2.credentials.Credentials(**credentials_dict)
     user_info_service = googleapiclient.discovery.build(
         serviceName=service_name, version=version, credentials=credentials
@@ -150,7 +163,9 @@ def get_user_info(credentials_dict, service_name="oauth2", version="v2"):
     return user_info, error, credentials
 
 
-def _credentials_to_dict(credentials):
+def _credentials_to_dict(
+    credentials: google.oauth2.credentials.Credentials,
+) -> dict[str, Any]:
     return {
         "token": credentials.token,
         "refresh_token": credentials.refresh_token,

--- a/gmailsorter/webapp/render.py
+++ b/gmailsorter/webapp/render.py
@@ -1,7 +1,7 @@
 from gmailsorter.daemon.shared import JOB_STATUS_FAIL, JOB_STATUS_SUCCESS
 
 
-def color_for_status(status):
+def color_for_status(status: str) -> str:
     if status == JOB_STATUS_SUCCESS:
         return '<span style="color:MediumSeaGreen;">' + status + "</span>"
     elif status == JOB_STATUS_FAIL:

--- a/gmailsorter/webapp/user.py
+++ b/gmailsorter/webapp/user.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 from flask_login import UserMixin
+from sqlalchemy import Engine
 from sqlalchemy.orm import sessionmaker
 
 from gmailsorter.daemon import SQLUser, get_token
@@ -11,16 +14,16 @@ from gmailsorter.webapp.database import (
 class FlaskUser(UserMixin):
     def __init__(
         self,
-        database_id,
-        google_id,
-        name,
-        email,
-        profile_pic,
-        token,
-        refresh_token,
-        token_uri,
-        expiry,
-    ):
+        database_id: int,
+        google_id: str,
+        name: str | None,
+        email: str | None,
+        profile_pic: str | None,
+        token: str | None,
+        refresh_token: str | None,
+        token_uri: str | None,
+        expiry: datetime | None,
+    ) -> None:
         self.id = google_id
         self.database_id = database_id
         self.name = name
@@ -33,19 +36,19 @@ class FlaskUser(UserMixin):
 
 
 def get_flask_user(
-    engine,
-    google_id,
-    users_name=None,
-    users_email=None,
-    picture=None,
-    token=None,
-    refresh_token=None,
-    token_uri=None,
-    client_id=None,
-    client_secret=None,
-    expiry=None,
-    update=True,
-):
+    engine: Engine,
+    google_id: str,
+    users_name: str | None = None,
+    users_email: str | None = None,
+    picture: str | None = None,
+    token: str | None = None,
+    refresh_token: str | None = None,
+    token_uri: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    expiry: datetime | None = None,
+    update: bool = True,
+) -> FlaskUser | None:
     session = sessionmaker(bind=engine)()
     user = session.query(SQLUser).filter_by(google_id=google_id).first()
     if not update:


### PR DESCRIPTION
## Summary
- Add type annotations to function signatures, class constructors, and return types across `base`, `google`, `daemon`, `ml`, and `webapp`.
- Goal: make it easier for new contributors to navigate the codebase with IDE autocomplete/type-checker support, per request.
- No behavior changes; `ruff check`/`ruff format` pass cleanly on `gmailsorter/`.

Note: SQLAlchemy models still use the classic `declarative_base()`/`Column()` style, which `mypy` doesn't type-check precisely (it would require migrating to `Mapped`/`mapped_column`, SQLAlchemy 2.0 style). That migration is a separate, larger change and out of scope here.

## Test plan
- [x] `ruff check gmailsorter` and `ruff format --check gmailsorter` pass
- [x] Full test suite (`pytest tests/`) passes: 152 passed